### PR TITLE
Add missing documents to navigation and standardize markdown formatting

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,11 +22,23 @@
 - [zApps Draft Notes](notes/zapps-draft-notes.md)
 - [Minimal Sentry Node](notes/minimal-sentry-node.md)
 - [Browser Light Client](notes/browser-light-client.md)
+- [Bitcoin SPV Feasibility](notes/bitcoin-spv-feasibility.md)
+- [Browser Light Client (Extended)](notes/browser-light-client/README.md)
+- [Minimal Sentry Node (Extended)](notes/minimal-sentry-node/README.md)
+- [SPV Light Verification (Extended)](notes/spv-light-verification/README.md)
+- [zApps Draft Notes (Extended)](notes/zapps-draft-notes/README.md)
 
 ## Research
 - [Research Index](research/README.md)
 - [Bitcoin SPV on Zenon — Research Blueprint](research/bitcoin-spv-research-blueprint.md)
 - [Transaction Admission Control](research/transaction-admission-control.md)
+- [External Resources](research/external-resources.md)
+- [Browser Light Client Overview](research/browser-light-client-overview.md)
+- [Open Research Questions](research/open-research-questions.md)
+- [Engineering Roadmap: Bitcoin SPV](research/engineering-roadmap-bitcoin-spv.md)
+- [Taxonomy: Deterministic Fact Acceptance](research/taxonomy-deterministic-fact-acceptance.md)
+- [Header-Only Verification Research](research/header-only-verification-research.md)
+- [Header-Only Verification Hostile Review](research/header-only-verification-hostile-review.md)
 
 ## Proposals
 - [Proposals Index](proposals/README.md)

--- a/docs/notes/README.md
+++ b/docs/notes/README.md
@@ -15,10 +15,14 @@ These are exploratory research documents, not protocol specifications.
 ## Core Architecture
 
 - [Browser Light Client Architecture](browser-light-client-architecture.md)
+- [Browser Light Client](browser-light-client.md)
 - [Account Chain Commitments](account-chain-commitments.md)
 - [Momentum Header Verification](momentum-header-verification.md)
+- [Momentum Data Fields](momentum-data-fields.md)
 - [Pillars](pillars.md)
 - [Supervisor Layer](supervisor-layer.md)
+- [Minimal Sentry Node](minimal-sentry-node.md)
+- [zApps Draft Notes](zapps-draft-notes.md)
 
 ---
 
@@ -27,6 +31,8 @@ These are exploratory research documents, not protocol specifications.
 - [State Proof Bundles](state-proof-bundles.md)
 - [Sentinel Finalization Layer](sentinel-finalization-layer.md)
 - [Sentinel Middle Layer](sentinel-middle-layer.md)
+- [SPV Light Verification](spv-light-verification.md)
+- [Bitcoin SPV Feasibility](bitcoin-spv-feasibility.md)
 
 ---
 

--- a/docs/notes/account-chain-commitments.md
+++ b/docs/notes/account-chain-commitments.md
@@ -1,195 +1,158 @@
-Account-Chain Commitments & ChangesHash (Draft Notes)
+# Account-Chain Commitments & ChangesHash
+
+Research Note — Draft Notes
 
 These notes clarify how account-chain transitions are committed inside Momentum blocks, how ChangesHash functions in practice, and why this structure is sufficient for lightweight verification without Merkle inclusion proofs.
 
-This is not a full specification.
-It is an architectural description for researchers exploring SPV, browser-native execution, and potential cross-chain extensions.
+This is not a full specification. It is an architectural description for researchers exploring SPV, browser-native execution, and potential cross-chain extensions.
 
-⸻
+---
 
-1. Why This Matters
+## 1. Why This Matters
 
 In Bitcoin, SPV depends on Merkle proofs because each transaction is an independent leaf inside a block.
 
 Zenon does not work this way.
 
-Zenon’s dual-ledger structure means:
+Zenon's dual-ledger structure means:
 
-	•	user activity forms an account-chain
+- user activity forms an account-chain
+- Momentum blocks finalize references to those chains
+- global consensus never re-executes account logic
+- the system commits to state transitions, not transactions
 
-	•	Momentum blocks finalize references to those chains
+Understanding this difference removes many perceived "roadblocks" around SPV and light verification.
 
-	•	global consensus never re-executes account logic
-	
-	•	the system commits to state transitions, not transactions
+---
 
-Understanding this difference removes many perceived “roadblocks” around SPV and light verification.
-
-⸻
-
-2. What a Momentum Actually Commits To
+## 2. What a Momentum Actually Commits To
 
 A Momentum includes:
 
-	•	the ordered list of account-block headers
-
-	•	the resulting state modifications after applying all included account blocks
-	
-	•	a single cryptographic commitment to these changes (ChangesHash)
-
-	•	metadata such as timestamp, producer, version, and the optional future Data field
+- the ordered list of account-block headers
+- the resulting state modifications after applying all included account blocks
+- a single cryptographic commitment to these changes (ChangesHash)
+- metadata such as timestamp, producer, version, and the optional future Data field
 
 Key point:
 ChangesHash is a commitment to the aggregate effect of all included account-chain transitions.
 
 It does not need to expose:
-	
-	•	Merkle roots
 
-	•	per-block inclusion proofs
-
-	•	contract execution details
-
-	•	global state snapshots
+- Merkle roots
+- per-block inclusion proofs
+- contract execution details
+- global state snapshots
 
 A verifier only needs to know that:
-	
-	1.	the Pillar was eligible to produce the Momentum
 
-	2.	the included account-block headers are valid
-	
-	3.	the resulting state transition is correct and reproducible
+1. the Pillar was eligible to produce the Momentum
+2. the included account-block headers are valid
+3. the resulting state transition is correct and reproducible
 
 This is a much lighter model than Bitcoin-style SPV.
 
-⸻
+---
 
-3. Why No Merkle Tree Is Required
+## 3. Why No Merkle Tree Is Required
 
-Because Zenon’s execution model is local-first:
+Because Zenon's execution model is local-first:
 
-	•	each account-chain is internally ordered and self-verifying
-	
-	•	a new account-block implicitly validates the previous one
-
-	•	Momentum commits to the frontier state after applying included blocks
+- each account-chain is internally ordered and self-verifying
+- a new account-block implicitly validates the previous one
+- Momentum commits to the frontier state after applying included blocks
 
 So instead of asking:
 
-“Was this individual transaction included in the block?”
+"Was this individual transaction included in the block?"
 
 A verifier asks:
 
-“Does this Momentum commit to the correct frontier of this account-chain?”
+"Does this Momentum commit to the correct frontier of this account-chain?"
 
 This makes SPV fundamentally simpler:
-	
-	•	proving inclusion of account-block N implicitly proves N-1, N-2, …
 
-	•	no Merkle branches are required
+- proving inclusion of account-block N implicitly proves N-1, N-2, …
+- no Merkle branches are required
+- the Momentum header + the account-chain frontier hash become the proof object
 
-	•	the Momentum header + the account-chain frontier hash become the proof object
+---
 
-⸻
-
-4. How ChangesHash Fits Into This Model
+## 4. How ChangesHash Fits Into This Model
 
 ChangesHash represents the cryptographic digest of:
-	
-	•	balance updates
 
-	•	account-chain header updates
-
-	•	confirmation heights
-	
-	•	mailbox changes
-
-	•	sequencer queue updates
-
-	•	embedded contract state changes
-	
-	•	staking and fusion metadata
-
-	•	token definitions
-
-	•	any deterministic component of the state machine
+- balance updates
+- account-chain header updates
+- confirmation heights
+- mailbox changes
+- sequencer queue updates
+- embedded contract state changes
+- staking and fusion metadata
+- token definitions
+- any deterministic component of the state machine
 
 It is the global commitment object.
 
 A light verifier does not need to recompute these values.
 It only needs to:
-	
-	1.	verify the Momentum header signature
 
-	2.	verify chain continuity
-
-	3.	verify the referenced account-chain block
+1. verify the Momentum header signature
+2. verify chain continuity
+3. verify the referenced account-chain block
 
 This is the core of header-first SPV for Zenon.
 
-⸻
+---
 
-5. Account-Chain Frontier Verification (The Lightest Possible Model)
+## 5. Account-Chain Frontier Verification (The Lightest Possible Model)
 
 A minimal browser or sentry verifier only requires:
 
-	1.	the Momentum header
-
-	2.	the account-chain frontier header referenced by that Momentum
-	
-	3.	the parent account-block hash
+1. the Momentum header
+2. the account-chain frontier header referenced by that Momentum
+3. the parent account-block hash
 
 From this it can verify:
-	
-	•	the account-chain is valid
 
-	•	the Momentum references the correct frontier
-
-	•	the Momentum originates from a valid Pillar
-
-	•	cumulative weight / score is correct
-
-	•	timestamps and eligibility rules match
+- the account-chain is valid
+- the Momentum references the correct frontier
+- the Momentum originates from a valid Pillar
+- cumulative weight / score is correct
+- timestamps and eligibility rules match
 
 No Merkle proofs are needed.
 
-⸻
+---
 
-6. Why This Enables SPV, zApps, and Cross-Chain Work
+## 6. Why This Enables SPV, zApps, and Cross-Chain Work
 
-SPV:
+**SPV:**
 Verifiers only need Momentum headers + account-chain frontiers.
 
-zApps:
+**zApps:**
 Logic executes locally; the output becomes an account-chain transition anchored by the Momentum.
 
-Cross-chain:
-Momentum’s reserved Data field can eventually support:
+**Cross-chain:**
+Momentum's reserved Data field can eventually support:
 
-	•	external Merkle roots
-
-	•	succinct proofs
-
-	•	state commitments
-
-	•	interoperability metadata
+- external Merkle roots
+- succinct proofs
+- state commitments
+- interoperability metadata
 
 The model is structurally ready for these extensions.
 
-⸻
+---
 
-7. Open Questions
+## 7. Open Questions
 
 These research directions remain:
-	
-	•	What subset of ChangesHash should be exposed to light clients?
-	
-	•	How should account-chain frontier data be packaged for verifiers?
 
-	•	Should Momentum Data evolve into a commitment extension field?
-	
-	•	Which proof systems best fit browser-native verification?
-	
-	•	How to formalize a light-client spec without modifying consensus?
+- What subset of ChangesHash should be exposed to light clients?
+- How should account-chain frontier data be packaged for verifiers?
+- Should Momentum Data evolve into a commitment extension field?
+- Which proof systems best fit browser-native verification?
+- How to formalize a light-client spec without modifying consensus?
 
 Future drafts will explore these topics in more detail.

--- a/docs/notes/browser-light-client/README.md
+++ b/docs/notes/browser-light-client/README.md
@@ -1,0 +1,12 @@
+# Browser Light Client (Extended Drafts)
+
+## TODO
+
+This folder will contain extended drafts exploring browser-native light client implementation:
+
+- WebRTC/libp2p transport integration
+- WASM-based cryptographic primitives
+- Momentum header sync protocols
+- Account-chain state management in IndexedDB
+- Micro-PoW generation in Web Workers
+- Session lifecycle and reconnection handling

--- a/docs/notes/dynamic-plasma.md
+++ b/docs/notes/dynamic-plasma.md
@@ -1,8 +1,6 @@
 # Dynamic Plasma: Adaptive Resource Scaling (Draft)
 
-Dynamic Plasma (DP) refers to an adaptive mechanism for regulating resource consumption in Zenon's dual-ledger architecture.
-This draft outlines why a static plasma model is insufficient, how adaptive scaling could operate, and how it interacts with account-chains, zApps, and future protocol extensions.
-It is a research framing, not a finalized specification.
+Dynamic Plasma (DP) refers to an adaptive mechanism for regulating resource consumption in Zenon's dual-ledger architecture. This draft outlines why a static plasma model is insufficient, how adaptive scaling could operate, and how it interacts with account-chains, zApps, and future protocol extensions. It is a research framing, not a finalized specification.
 
 ## 1. Purpose of Dynamic Plasma
 

--- a/docs/notes/minimal-sentry-node/README.md
+++ b/docs/notes/minimal-sentry-node/README.md
@@ -1,0 +1,12 @@
+# Minimal Sentry Node (Extended Drafts)
+
+## TODO
+
+This folder will contain extended drafts on minimal Sentry node design:
+
+- Stateless relay architecture
+- Light client connection management
+- Proof request forwarding to Sentinels
+- Local caching strategies without global state
+- Hardware requirements and deployment scenarios
+- Multi-client multiplexing

--- a/docs/notes/momentum-data-fields.md
+++ b/docs/notes/momentum-data-fields.md
@@ -1,107 +1,96 @@
-Momentum Data Field as an Extension Point in Dual-Ledger Protocols
+# Momentum Data Field as an Extension Point in Dual-Ledger Protocols
 
 Research Note — Exploratory, Non-Normative
 
-0. Scope and intent
+## Scope and intent
 
-This note examines the “Data” field present in Zenon Momentum headers as a potential extension mechanism. It does not propose a specific roadmap or claim any particular feature is planned; it only describes observable properties and outlines plausible research directions.
+This note examines the "Data" field present in Zenon Momentum headers as a potential extension mechanism. It does not propose a specific roadmap or claim any particular feature is planned; it only describes observable properties and outlines plausible research directions.
 
-⸻
+---
 
-1. What is explicitly documented or directly observable
+## 1. What is explicitly documented or directly observable
 
-1.1 Momentum headers include a Data field
+### 1.1 Momentum headers include a Data field
 
 Momentum headers contain a fixed set of fields used to form the Momentum hash. Among these is a Data field. This is observable in node implementations/struct definitions and in serialized header formats.
 
-1.2 The Data field is hash-committed
+### 1.2 The Data field is hash-committed
 
-Because it is part of the Momentum header, any non-empty value would be included in the Momentum hash and therefore is cryptographically committed under the producer’s signature and the chain’s header linkage.
+Because it is part of the Momentum header, any non-empty value would be included in the Momentum hash and therefore is cryptographically committed under the producer's signature and the chain's header linkage.
 
-1.3 Current validation rules require the field to be empty
+### 1.3 Current validation rules require the field to be empty
 
 In current implementations, the network enforces Data must be empty (or equivalent rule), meaning the field exists structurally but is not presently used for carrying payloads.
 
-⸻
+---
 
-2. Implications that follow directly from the above (low-inference)
+## 2. Implications that follow directly from the above (low-inference)
 
-2.1 It is an “available slot” in the commitment surface
+### 2.1 It is an "available slot" in the commitment surface
 
 Even if unused today, a header field that is:
 
-	•	present in consensus-visible data,
-
-	•	included in the hash,
-
-	•	and validated by nodes,
+- present in consensus-visible data,
+- included in the hash,
+- and validated by nodes,
 
 is a natural place where future protocol versions could introduce new commitments without changing account-chain structure.
 
-2.2 Activation would be a consensus change
+### 2.2 Activation would be a consensus change
 
-Relaxing “must be empty” to “may be non-empty under rules X” would require a coordinated protocol upgrade (versioning and validation changes). This is a key point: the existence of the field does not imply it is live.
+Relaxing "must be empty" to "may be non-empty under rules X" would require a coordinated protocol upgrade (versioning and validation changes). This is a key point: the existence of the field does not imply it is live.
 
-⸻
+---
 
-3. Hypotheses and research directions (clearly labeled as inference)
+## 3. Hypotheses and research directions (clearly labeled as inference)
 
 The following are plausible uses in general for a hash-committed header payload slot in a dual-ledger system. These are not claims about what Zenon will do—only categories worth evaluating.
 
-3.1 Cross-chain commitment container (hypothesis)
+### 3.1 Cross-chain commitment container (hypothesis)
 
 A header-level payload could commit to external-chain artifacts (e.g., header tips, checkpoints, aggregated receipts) to enable interoperability primitives without embedding full external execution.
 
-3.2 Succinct proof anchoring (hypothesis)
+### 3.2 Succinct proof anchoring (hypothesis)
 
 A Data payload could carry references to succinct proofs (e.g., zk proof commitments) or state roots produced off-chain—acting as a settlement anchor while keeping L1 verification bounded.
 
-3.3 Protocol signaling / parameter commitments (hypothesis)
+### 3.3 Protocol signaling / parameter commitments (hypothesis)
 
 A Data payload could commit to network-wide parameters (e.g., resource targets, difficulty-related metadata, governance flags) in a way that is globally ordered and cheaply verifiable.
 
-3.4 Application-level commitments (hypothesis)
+### 3.4 Application-level commitments (hypothesis)
 
-A Data payload could commit to “global” application artifacts (receipts, coordination hashes, bundle commitments) without turning the base layer into a general-purpose VM.
+A Data payload could commit to "global" application artifacts (receipts, coordination hashes, bundle commitments) without turning the base layer into a general-purpose VM.
 
-⸻
+---
 
-4. Light-client considerations (research constraints, not promises)
+## 4. Light-client considerations (research constraints, not promises)
 
 If the Data field ever becomes active, a conservative research constraint is:
 
-	•	Keep it compact and interpretable without extra global state, so that header-first verification remains feasible for constrained clients.
+- Keep it compact and interpretable without extra global state, so that header-first verification remains feasible for constrained clients.
+- Define deterministic schemas so nodes and light clients do not diverge on interpretation.
+- Bound size to avoid turning "header sync" into "payload sync".
 
-	•	Define deterministic schemas so nodes and light clients do not diverge on interpretation.
+---
 
-	•	Bound size to avoid turning “header sync” into “payload sync”.
-
-⸻
-
-5. Minimal activation sketch (descriptive only)
+## 5. Minimal activation sketch (descriptive only)
 
 A clean upgrade path in principle would involve:
 
-	•	a header/version bump (or feature flag),
-
-	•	relaxing “Data must be empty” to “Data allowed under schema set S”,
-
-	•	deterministic parsing and size bounds,
-
-	•	explicit validation rules (what is permitted / rejected).
+- a header/version bump (or feature flag),
+- relaxing "Data must be empty" to "Data allowed under schema set S",
+- deterministic parsing and size bounds,
+- explicit validation rules (what is permitted / rejected).
 
 This is a consensus-level change, not an application-layer tweak.
 
-⸻
+---
 
-6. Open research questions
+## 6. Open research questions
 
-	•	What payload formats remain future-proof (single blob vs typed segments)?
-
-	•	What size bounds preserve light-client viability?
-
-	•	Should payload validation be “structural only” or “semantic” at L1?
-
-	•	How is data availability handled (who serves the referenced artifacts)?
-
-	•	How do we prevent payload misuse (spam vectors, bloat vectors)?
+- What payload formats remain future-proof (single blob vs typed segments)?
+- What size bounds preserve light-client viability?
+- Should payload validation be "structural only" or "semantic" at L1?
+- How is data availability handled (who serves the referenced artifacts)?
+- How do we prevent payload misuse (spam vectors, bloat vectors)?

--- a/docs/notes/pillars.md
+++ b/docs/notes/pillars.md
@@ -2,8 +2,7 @@
 
 Research Draft — Not a Formal Specification
 
-These notes describe how Pillars function inside Zenon's dual-ledger architecture, how they finalize ordering, and how they interact with Sentries and Sentinels.
-They are intended for researchers exploring browser-native verification, proof-first consensus, and lightweight execution models.
+These notes describe how Pillars function inside Zenon's dual-ledger architecture, how they finalize ordering, and how they interact with Sentries and Sentinels. They are intended for researchers exploring browser-native verification, proof-first consensus, and lightweight execution models.
 
 ## 1. Purpose of Pillars
 

--- a/docs/notes/sentinel-finalization-layer.md
+++ b/docs/notes/sentinel-finalization-layer.md
@@ -1,10 +1,10 @@
 # Sentinel Finalization Layer
 
-Research Notes on Proof Anchoring in a Dual-Ledger Architecture
+Research Note — Proof Anchoring in a Dual-Ledger Architecture
 
-Status: Exploratory research note
-Scope: Interpretation of documented Sentinel behavior and its role in a dual-ledger system
-Note: This document distinguishes between documented behavior and inferred architectural roles. It is not a specification.
+This document explores the Sentinel role as a verification and anchoring layer between account-level activity and Momentum-level ordering. It distinguishes between documented behavior and inferred architectural roles. This is exploratory research, not a specification.
+
+---
 
 ## 1. Introduction
 

--- a/docs/notes/sentinel-middle-layer.md
+++ b/docs/notes/sentinel-middle-layer.md
@@ -2,8 +2,7 @@
 
 These notes outline how Sentinels fit into Zenon's architecture as the deterministic verification and relay layer between lightweight Sentries and consensus-producing Pillars.
 
-This is not a formal specification.
-It is an architectural framing for researchers investigating light-node design, SPV patterns, and browser-native execution.
+This is not a formal specification. It is an architectural framing for researchers investigating light-node design, SPV patterns, and browser-native execution.
 
 ---
 

--- a/docs/notes/spv-light-verification.md
+++ b/docs/notes/spv-light-verification.md
@@ -1,7 +1,6 @@
 # SPV for Zenon (Draft Notes)
 
-These are early notes on what a minimal SPV-style verification model for Zenon might look like.
-This is not a proposal or spec — just an outline for exploring how SPV fits into the dual-ledger architecture.
+These are early notes on what a minimal SPV-style verification model for Zenon might look like. This is not a proposal or spec — just an outline for exploring how SPV fits into the dual-ledger architecture.
 
 ## Why SPV matters in this context
 

--- a/docs/notes/spv-light-verification/README.md
+++ b/docs/notes/spv-light-verification/README.md
@@ -1,0 +1,12 @@
+# SPV Light Verification (Extended Drafts)
+
+## TODO
+
+This folder will contain extended drafts on SPV-style verification for Zenon:
+
+- Momentum header chain verification
+- Account-chain frontier proofs
+- Minimal proof bundle schemas
+- Verification without global state
+- Trust assumptions and security model
+- Comparison with Bitcoin SPV

--- a/docs/notes/zapps-draft-notes/README.md
+++ b/docs/notes/zapps-draft-notes/README.md
@@ -1,0 +1,12 @@
+# zApps Draft Notes (Extended Drafts)
+
+## TODO
+
+This folder will contain extended drafts on zApp development and execution:
+
+- Deterministic execution guarantees
+- Local-first computation model
+- Commitment and proof generation
+- Multi-party zApp coordination
+- Browser/WASM runtime considerations
+- ACI schema definitions and validation

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,15 +1,34 @@
 # Research
 
-This folder collects open research questions, investigations, and exploratory ideas about Zenon’s design.
-
-This includes:
-
-- Browser-native light client feasibility
-- libp2p and WebRTC transport research
-- Proof-serving and Sentry mechanics
-- Deterministic execution models
-- Cryptographic design patterns
-- Scalability considerations
-- Role of extension chains vs native features
+This folder collects open research questions, investigations, and exploratory ideas about Zenon's design.
 
 Research here is exploratory, not authoritative. The goal is curiosity and clarity.
+
+---
+
+## Light Client Research
+
+- [Browser-Native Light Client Overview](browser-light-client-overview.md)
+- [Header-Only Verification Research](header-only-verification-research.md)
+- [Header-Only Verification Hostile Review](header-only-verification-hostile-review.md)
+
+---
+
+## Bitcoin SPV Research
+
+- [Bitcoin SPV on Zenon — Research Blueprint](bitcoin-spv-research-blueprint.md)
+- [Engineering Roadmap: Bitcoin SPV](engineering-roadmap-bitcoin-spv.md)
+
+---
+
+## Protocol & Execution Model
+
+- [Taxonomy: Deterministic Fact Acceptance](taxonomy-deterministic-fact-acceptance.md)
+- [Transaction Admission Control](transaction-admission-control.md)
+- [Open Research Questions](open-research-questions.md)
+
+---
+
+## External Resources
+
+- [External Resources](external-resources.md)

--- a/docs/research/header-only-verification-hostile-review.md
+++ b/docs/research/header-only-verification-hostile-review.md
@@ -1,0 +1,12 @@
+# Header-Only Verification — Hostile Review
+
+This document provides a critical analysis and hostile review of the header-only verification approach for Zenon.
+
+## Download
+
+<a href="header_only_verification_hostile_review.pdf" target="_blank">Download the hostile review (PDF)</a>
+
+## Related Documents
+
+- [Header-Only Verification Research](header-only-verification-research.md)
+- [Open Research Questions](open-research-questions.md)

--- a/docs/research/header-only-verification-research.md
+++ b/docs/research/header-only-verification-research.md
@@ -1,0 +1,12 @@
+# Header-Only Verification Research
+
+This document presents research on header-only verification approaches for the Zenon Network of Momentum.
+
+## Download
+
+<a href="header_only_verification_research_v3_final.pdf" target="_blank">Download the full research paper (PDF)</a>
+
+## Related Documents
+
+- [Browser Light Client Overview](browser-light-client-overview.md)
+- [Open Research Questions](open-research-questions.md)

--- a/docs/research/taxonomy-deterministic-fact-acceptance.md
+++ b/docs/research/taxonomy-deterministic-fact-acceptance.md
@@ -1,121 +1,120 @@
-Taxonomy Note: Deterministic Fact Acceptance
+# Taxonomy Note: Deterministic Fact Acceptance
 
 Research Note — Terminology & Classification
 
-Purpose
+## Purpose
 
 This note clarifies the architectural category explored in this repository and distinguishes it from adjacent but non-equivalent blockchain models. Its goal is to reduce misclassification, not to assert novelty or superiority.
 
-Core Term
-Deterministic Fact Acceptance (DFA)
+---
 
-Definition:
+## Core Term: Deterministic Fact Acceptance (DFA)
+
+**Definition:**
 A ledger model in which consensus admits state transitions based solely on deterministic verification of facts, while the computation or execution that produces those facts is local, discardable, and non-authoritative.
 
 In a DFA model:
 
-execution is permitted but never trusted
+- execution is permitted but never trusted
+- verification predicates are consensus-relevant
+- execution traces are not replayed globally
+- correctness is established without running foreign logic
 
-verification predicates are consensus-relevant
+---
 
-execution traces are not replayed globally
-
-correctness is established without running foreign logic
-
-What DFA Is Not
+## What DFA Is Not
 
 DFA is often conflated with existing categories due to shared primitives. These mappings are incorrect:
 
-Not Smart Contract Platforms
+### Not Smart Contract Platforms
 
-Smart contracts require global execution or replay.
+- Smart contracts require global execution or replay.
+- DFA systems do not execute application logic in consensus.
+- Determinism arises from structural predicates, not VM execution.
 
-DFA systems do not execute application logic in consensus.
+### Not Light Clients
 
-Determinism arises from structural predicates, not VM execution.
+- Light clients are clients of an execution chain.
+- DFA describes a ledger model itself, not a client optimization.
 
-Not Light Clients
+### Not Stateless Clients
 
-Light clients are clients of an execution chain.
+- Stateless clients optimize state access.
+- DFA changes which computations are consensus-critical.
 
-DFA describes a ledger model itself, not a client optimization.
+### Not Rollups
 
-Not Stateless Clients
+- Rollups execute off-chain but still require fraud/validity proofs tied to execution correctness.
+- DFA accepts facts without referencing execution traces at all.
 
-Stateless clients optimize state access.
+### Not Oracles or Bridges
 
-DFA changes which computations are consensus-critical.
+- Oracles introduce trust assumptions.
+- DFA relies only on cryptographic verification of supplied facts.
 
-Not Rollups
+---
 
-Rollups execute off-chain but still require fraud/validity proofs tied to execution correctness.
-
-DFA accepts facts without referencing execution traces at all.
-
-Not Oracles or Bridges
-
-Oracles introduce trust assumptions.
-
-DFA relies only on cryptographic verification of supplied facts.
-
-Canonical Comparison Axis
+## Canonical Comparison Axis
 
 Most blockchains are classified by what is committed.
 DFA is classified by what must be executed.
 
-Dimension	Execution-Centric Chains	DFA Model
-Execution	Global, authoritative	Local, non-authoritative
-Verification	Implied by execution	Explicit predicate
-Commitment	Execution outcome	Fact only
-Failure Mode	Fork / consensus fault	Verification fails → no-op
-Scalability Cost	Validator count × execution	Bounded verification only
-Relationship to Known Systems
-Bitcoin SPV
+| Dimension | Execution-Centric Chains | DFA Model |
+|-----------|--------------------------|-----------|
+| Execution | Global, authoritative | Local, non-authoritative |
+| Verification | Implied by execution | Explicit predicate |
+| Commitment | Execution outcome | Fact only |
+| Failure Mode | Fork / consensus fault | Verification fails → no-op |
+| Scalability Cost | Validator count × execution | Bounded verification only |
 
-Bitcoin SPV is an instance of DFA applied to transaction inclusion.
+---
 
-DFA generalizes the pattern beyond Bitcoin.
+## Relationship to Known Systems
 
-Ethereum / Verkle / Statelessness
+### Bitcoin SPV
 
-These optimize proof size and state access.
+- Bitcoin SPV is an instance of DFA applied to transaction inclusion.
+- DFA generalizes the pattern beyond Bitcoin.
 
-They do not remove execution from consensus.
+### Ethereum / Verkle / Statelessness
 
-Algorand State Proofs
+- These optimize proof size and state access.
+- They do not remove execution from consensus.
 
-Compress attestation of executed state.
+### Algorand State Proofs
 
-Still rely on protocol-defined execution correctness.
+- Compress attestation of executed state.
+- Still rely on protocol-defined execution correctness.
 
-Why DFA Is Easy to Misclassify
+---
 
-It uses familiar cryptographic tools (Merkle proofs, headers).
+## Why DFA Is Easy to Misclassify
 
-It removes an implicit assumption (global execution).
-
-Most blockchain literature does not separate execution from acceptance.
+- It uses familiar cryptographic tools (Merkle proofs, headers).
+- It removes an implicit assumption (global execution).
+- Most blockchain literature does not separate execution from acceptance.
 
 As a result, readers often map DFA to the nearest known category (SPV, light clients) unless the distinction is made explicit.
 
-Non-Goals of DFA
+---
+
+## Non-Goals of DFA
 
 DFA does not attempt to:
 
-prevent malicious software
-
-verify user intent
-
-sandbox arbitrary computation
-
-provide general-purpose on-chain execution
+- prevent malicious software
+- verify user intent
+- sandbox arbitrary computation
+- provide general-purpose on-chain execution
 
 It enforces outcome correctness, not behavioral guarantees.
 
-Summary
+---
+
+## Summary
 
 Deterministic Fact Acceptance names a ledger-level responsibility split that is usually implicit or conflated:
 
-Consensus verifies facts, not execution.
+**Consensus verifies facts, not execution.**
 
 This taxonomy clarifies how systems can support interoperability, external verification, and scalable admission control without inheriting the costs of global execution.


### PR DESCRIPTION
Navigation updates:
- Add all missing docs from /notes and /research to SUMMARY.md
- Create wrapper pages for PDF files (GitBook compatibility)
- Add extended drafts subdirectories with TODO landing pages
- Update notes/README.md and research/README.md with categorized links

Formatting standardization:
- Convert plain text headings to proper markdown (# ## ###)
- Fix list formatting (use - prefix consistently)
- Add section separators (---) between major sections
- Standardize document headers with subtitle format

New files:
- PDF wrapper pages for header-only verification research
- Subdirectory README.md files for extended drafts