### PR TITLE
Added landing pages for the Notes Subcategories 

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,14 +8,14 @@
 
 ## Notes (Draft Research & Working Documents)
 - [Notes Index](notes/README.md)
-- Node Architecture
-  - [Pillars](notes/pillars.md)
-  - [Sentinel Finalization Layer](notes/sentinel-finalization-layer.md)
-  - [Sentinel Middle Layer](notes/sentinel-middle-layer.md)
-  - [Supervisor Layer](notes/supervisor-layer.md)
+- [Node Architecture](notes/node-architecture.md)
   - [Minimal Sentry Node](notes/minimal-sentry-node.md)
   - [Minimal Sentry Node (Extended)](notes/minimal-sentry-node/README.md)
-- Light Clients & Verification
+  - [Supervisor Layer](notes/supervisor-layer.md)
+  - [Sentinel Middle Layer](notes/sentinel-middle-layer.md)
+  - [Sentinel Finalization Layer](notes/sentinel-finalization-layer.md)
+  - [Pillars](notes/pillars.md)
+- [Light Clients & Verification](notes/light-clients-verification.md)
   - [Momentum Header Verification](notes/momentum-header-verification.md)
   - [SPV Light Verification](notes/spv-light-verification.md)
   - [SPV Light Verification (Extended)](notes/spv-light-verification/README.md)
@@ -23,14 +23,14 @@
   - [Browser Light Client](notes/browser-light-client.md)
   - [Browser Light Client Architecture](notes/browser-light-client-architecture.md)
   - [Browser Light Client (Extended)](notes/browser-light-client/README.md)
-- Data Structures & Commitments
+- [Data Structures & Commitments](notes/data-structures.md)
   - [Account Chain Commitments](notes/account-chain-commitments.md)
   - [Momentum Data Fields](notes/momentum-data-fields.md)
-- Execution Model
+- [Execution Model](notes/execution-model.md)
   - [zApps Draft Notes](notes/zapps-draft-notes.md)
   - [zApps Draft Notes (Extended)](notes/zapps-draft-notes/README.md)
   - [Dynamic Plasma](notes/dynamic-plasma.md)
-- Interoperability
+- [Interoperability](notes/interoperability.md)
   - [Bitcoin SPV Feasibility](notes/bitcoin-spv-feasibility.md)
   - [HTLCs, PTLCs, and Bounded Inclusion](notes/htlc_ptlc_and_bounded_inclusion_comparison.md)
 

--- a/docs/notes/browser-light-client.md
+++ b/docs/notes/browser-light-client.md
@@ -11,7 +11,7 @@ Some parts of the Zenon design line up well with modern browsers:
 - micro-PoW instead of gas
 - simple header verification
 
-Modern browsers can handle WASM, WebCrypto, and P2P transports.
+Modern browsers can handle WASM and P2P transports.
 
 ## What a minimal client would do
 

--- a/docs/notes/data-structures.md
+++ b/docs/notes/data-structures.md
@@ -1,0 +1,27 @@
+# Data Structures & Commitments
+
+How data is organized and committed in Zenon's dual-ledger architecture.
+
+---
+
+## Overview
+
+Zenon's dual-ledger model commits to state transitions rather than transactions. The account-chain DAG handles user activity while Momentums finalize references to those chains. This separation enables lightweight verification without requiring Merkle inclusion proofs or global state replay.
+
+---
+
+## Key Concepts
+
+**ChangesHash** — A cryptographic digest representing the aggregate effect of all account-chain transitions included in a Momentum. It commits to balance updates, confirmation heights, and all deterministic state machine components.
+
+**Account-Chain Frontiers** — Each account-chain is internally ordered and self verifying. A new account-block implicitly validates all previous blocks, making frontier verification sufficient for proving inclusion.
+
+**Momentum Data Field** — A reserved header field that is hash-committed but currently unused. This provides an extension point for future protocol features like cross-chain commitments or succinct proof anchoring.
+
+---
+
+## Documents in This Section
+
+- [Account Chain Commitments](account-chain-commitments.md) — How account-chain transitions are committed inside Momentums. Explains ChangesHash, why Merkle proofs aren't required, and the frontier verification model.
+
+- [Momentum Data Fields](momentum-data-fields.md) — Analysis of the Momentum Data field as a protocol extension point. Covers potential uses for cross-chain commitments, proof anchoring, and parameter signaling.

--- a/docs/notes/execution-model.md
+++ b/docs/notes/execution-model.md
@@ -1,0 +1,36 @@
+# Execution Model
+
+How application logic runs in Zenon without a global VM.
+
+---
+
+## Overview
+
+Zenon's execution model is local first. Instead of running smart contracts on a global virtual machine, users execute deterministic programs locally and commit only the results to their account-chains. Consensus nodes validate commitments, they never re-execute application logic.
+
+This enables:
+
+- Browser native execution via WASM or JavaScript
+- Parallel, non-competing workloads
+- Extremely cheap interactions without fee markets
+- Scalability without global state bottlenecks
+
+---
+
+## Key Concepts
+
+**zApps** — Deterministic programs executed by the user, with results anchored to the account-chain. Consensus only verifies that commitments are valid and transitions are well formed.
+
+**Local First Design** — Each user has their own account-chain, local state, and execution environment. No global VM interprets or runs application code.
+
+**Dynamic Plasma** — Adaptive resource constraints that regulate state growth and throughput without introducing fees. Plasma difficulty adjusts based on system load rather than competitive bidding.
+
+---
+
+## Documents in This Section
+
+- [zApps Draft Notes](zapps-draft-notes.md) — How application logic runs locally, remains deterministic, and anchors verifiable results to the dual-ledger. Covers the minimal workflow from local execution to Momentum finalization.
+
+- [zApps Draft Notes (Extended)](zapps-draft-notes/README.md) — Extended drafts and deeper exploration of the zApp execution model.
+
+- [Dynamic Plasma](dynamic-plasma.md) — Adaptive mechanism for regulating resource consumption. Explains how plasma difficulty adjusts to state growth while preserving a feeless user experience.

--- a/docs/notes/interoperability.md
+++ b/docs/notes/interoperability.md
@@ -1,0 +1,33 @@
+# Interoperability
+
+Cross-chain verification concepts and external data integration.
+
+---
+
+## Overview
+
+Zenon can consume external chain data as a unilateral fact oracle, verifying external consensus outputs (finality, ordering, cost) without executing external protocols or coordinating bidirectionally. This enables trustless cross-chain verification using standard cryptographic primitives.
+
+The dual-ledger architecture is structurally compatible with:
+
+- Bitcoin SPV header verification
+- Merkle inclusion proofs for external transactions
+- Bounded verification patterns like HTLCs and PTLCs
+
+---
+
+## Key Concepts
+
+**Unilateral Verification** — Zenon verifies external facts without participating in external consensus. External data becomes a committed fact once verified, requiring no ongoing coordination.
+
+**Bitcoin SPV Compatibility** — Bitcoin transaction verification is cryptographically possible using only header PoW verification, cumulative chainwork, Merkle proofs, and confirmation depth.
+
+**Bounded Verification Primitives** — HTLCs and PTLCs are special cases of bounded inclusion accepting state transitions when small, verifiable conditions are satisfied without re-executing global state.
+
+---
+
+## Documents in This Section
+
+- [Bitcoin SPV Feasibility](bitcoin-spv-feasibility.md) — Why Bitcoin transaction verification via SPV is cryptographically possible within Zenon's ledger model. Covers PoW headers, chainwork, Merkle proofs, and confirmation security.
+
+- [HTLCs, PTLCs, and Bounded Inclusion](htlc_ptlc_and_bounded_inclusion_comparison.md) — How familiar primitives like HTLCs and PTLCs relate to bounded inclusion. Clarifies that bounded verification is a generalization of patterns already proven successful.

--- a/docs/notes/light-clients-verification.md
+++ b/docs/notes/light-clients-verification.md
@@ -1,0 +1,43 @@
+# Light Clients & Verification
+
+Research into trustless verification models for resource-constrained environments.
+
+---
+
+## Overview
+
+Zenon's dual-ledger architecture enables lightweight verification without global state. Light clients can verify chain progress and account-chain updates using only:
+
+- Momentum headers
+- Compact state proofs
+- Local account-chain data
+
+This aligns naturally with SPV-style verification, making browser native and mobile clients viable as first class network participants.
+
+---
+
+## Key Concepts
+
+**Header-Only Verification** — Light nodes verify chain progress by validating Momentum headers (Pillar signatures, difficulty, weight) without downloading full blocks or global state.
+
+**State Proof Bundles** — Compact verification primitives that prove account-chain transitions without Merkle proofs or global state access.
+
+**Browser as Peer** — Modern browsers can perform cryptographic verification using WASM and P2P transports, enabling trustless participation without RPC gateways.
+
+---
+
+## Documents in This Section
+
+- [Momentum Header Verification](momentum-header-verification.md) — How light nodes verify chain progress: Pillar eligibility, chain continuity, and account-chain finality using only headers.
+
+- [SPV Light Verification](spv-light-verification.md) — Exploration of SPV-style verification for Zenon. Covers header verification, proof acceptance, and minimal state maintenance.
+
+- [SPV Light Verification (Extended)](spv-light-verification/README.md) — Extended notes on SPV patterns and implementation considerations.
+
+- [State Proof Bundles](state-proof-bundles.md) — Compact verification primitive for account-chain transitions. Explains why Merkle proofs aren't needed in the dual-ledger model.
+
+- [Browser Light Client](browser-light-client.md) — Early notes on minimal browser client: header sync, local signing, micro PoW generation, and transaction relay.
+
+- [Browser Light Client Architecture](browser-light-client-architecture.md) — Comprehensive research on browsers as verifiable peers. Covers verification responsibilities, networking, and state reconstruction.
+
+- [Browser Light Client (Extended)](browser-light-client/README.md) — Extended drafts and deeper exploration of browser client design.

--- a/docs/notes/node-architecture.md
+++ b/docs/notes/node-architecture.md
@@ -1,0 +1,50 @@
+# Node Architecture
+
+Overview of Zenon's node hierarchy and their roles in the Network of Momentum.
+
+---
+
+## The Node Hierarchy
+
+Zenon separates consensus from execution across a layered node architecture:
+
+```
+Sentries (Local Execution & Light Client Support)
+    ↓
+Supervisors (Aggregation & Proof Construction)
+    ↓
+Sentinels (Verification & Filtering)
+    ↓
+Pillars (Consensus)
+```
+
+Each layer has distinct responsibilities:
+
+1. **Sentries** — Execution layer. Run zApps locally, serve proofs to light clients.
+2. **Supervisors** — Coordination layer. Aggregate Sentry outputs, construct State Proof Bundles.
+3. **Sentinels** — Verification layer. Validate structure and filter spam before data reaches consensus.
+4. **Pillars** — Consensus layer. Produce Momentums, finalize ordering, apply deterministic state deltas.
+
+---
+
+## Key Insight
+
+> "Zenon consensus finalizes commitments to facts, not the correctness of execution that produced them."
+
+Execution happens at the edge (Sentries), not at consensus (Pillars). Pillars commit results, not processes. This separation enables scalability without sacrificing verification guarantees.
+
+---
+
+## Documents in This Section
+
+- [Pillars](pillars.md) — Consensus nodes that produce Momentums. They validate ordering and state transitions but don't execute contract logic.
+
+- [Sentinel Finalization Layer](sentinel-finalization-layer.md) — Explores Sentinels as a verification bridge between account-chains and Pillars, reducing the validation burden on consensus.
+
+- [Sentinel Middle Layer](sentinel-middle-layer.md) — Frames Sentinels as the deterministic verification and relay layer. Covers what they verify: structure, PoW, contract calls, transactions.
+
+- [Supervisor Layer](supervisor-layer.md) — Proposes an intermediate coordination layer that aggregates Sentry outputs, validates proof completeness, and constructs State Proof Bundles.
+
+- [Minimal Sentry Node](minimal-sentry-node.md) — Describes the smallest useful Sentry: no global state, modest hardware requirements, serves as a bridge between light clients and the network.
+
+- [Minimal Sentry Node (Extended)](minimal-sentry-node/README.md) — Extended notes and deeper exploration of Sentry design.


### PR DESCRIPTION
In the last PR we created Subcategories for 
- Node Architecture
- Light Clients & Verification
- Data Structures & Commitments
- Execution Model
- Interoperability

This PR adds a landing page for each Subcategory which introduces the topic, rather than just linking to articles.  These articles were written with the help of AI but reviewed and edited by me.  Please read these carefully to ensure accuracy.  This is the first PR I've made that actually creates new content.  All previous PRs were strictly formatting in nature.  The idea is to introduce the reader to the topics in the subsection rather than letting them figure it out themselves by reading the articles.  