### PR TITLE
[WIP] fix: add LaTeX math delimiters for GitHub Markdown compatibility

### DIFF
--- a/docs/research/engineering-roadmap-bitcoin-spv.md
+++ b/docs/research/engineering-roadmap-bitcoin-spv.md
@@ -72,25 +72,25 @@ Where:
 The verification function $V(\pi, z) \to \{0,1\}$ evaluates true iff all conditions hold:
 
 - **PoW Validity**
-  $$
-  \mathrm{SHA256}^2(H_i) \le T_i
-  $$
+$$
+\mathrm{SHA256}^2(H_i) \le T_i
+$$
 
 - **Maximal Chainwork**
-  $$
-  W_i = \left\lfloor \frac{2^{256}}{T_i + 1} \right\rfloor,\quad
-  W_{\text{chain}} = \sum_i W_i
-  $$
+$$
+W_i = \left\lfloor \frac{2^{256}}{T_i + 1} \right\rfloor,\quad
+W_{\text{chain}} = \sum_i W_i
+$$
 
 - **Merkle Inclusion**
-  $$
-  \mathrm{MerkleRoot}(tx,\text{branch}) = R(H_b)
-  $$
+$$
+\mathrm{MerkleRoot}(tx,\text{branch}) = R(H_b)
+$$
 
 - **Confirmation Depth**
-  $$
-  n - b \ge z
-  $$
+$$
+n - b \ge z
+$$
 
 **Security Note:**  
 For an attacker with hashpower fraction $q < 0.5$, the probability of reversing a transaction decays exponentially:
@@ -164,7 +164,7 @@ Mitigate header availability and eclipse risks.
 **Option A — Threshold Relaying:**  
 Accept a header tip $\hat{t}$ only if observed from at least $k$ independent sources:
 $$
-\#\{s_j : \mathrm{tip}(s_j)=\hat{t}\} \ge k
+| \{s_j : \mathrm{tip}(s_j)=\hat{t}\} | \ge k
 $$
 
 This threshold mechanism mitigates eclipse risk but does **not** constitute a separate consensus system or introduce new trust assumptions beyond standard SPV verification.

--- a/docs/research/engineering-roadmap-bitcoin-spv.md
+++ b/docs/research/engineering-roadmap-bitcoin-spv.md
@@ -72,22 +72,26 @@ Where:
 The verification function $V(\pi, z) \to \{0,1\}$ evaluates true iff all conditions hold:
 
 - **PoW Validity**
+
 $$
 \mathrm{SHA256}^2(H_i) \le T_i
 $$
 
 - **Maximal Chainwork**
+
 $$
 W_i = \left\lfloor \frac{2^{256}}{T_i + 1} \right\rfloor,\quad
 W_{\text{chain}} = \sum_i W_i
 $$
 
 - **Merkle Inclusion**
+
 $$
 \mathrm{MerkleRoot}(tx,\text{branch}) = R(H_b)
 $$
 
 - **Confirmation Depth**
+
 $$
 n - b \ge z
 $$
@@ -146,9 +150,11 @@ Verification cost is paid by the invoking account using existing resource mechan
 
 **Resource Bounds:**  
 To prevent abuse:
+
 $$
 C(\pi) \approx 2h + k \le C_{\max}
 $$
+
 where $h$ is header count and $k$ is Merkle branch length.
 
 **Outcome:**  
@@ -163,6 +169,7 @@ Mitigate header availability and eclipse risks.
 
 **Option A — Threshold Relaying:**  
 Accept a header tip $\hat{t}$ only if observed from at least $k$ independent sources:
+
 $$
 | \{s_j : \mathrm{tip}(s_j)=\hat{t}\} | \ge k
 $$

--- a/docs/research/engineering-roadmap-bitcoin-spv.md
+++ b/docs/research/engineering-roadmap-bitcoin-spv.md
@@ -43,13 +43,13 @@ The engineering path adheres to four binding constraints:
 
 We define the statement to be verified as:
 
-\[
+$$
 S(tx, z) := \text{“Bitcoin transaction } tx \text{ is included in the canonical Bitcoin chain and buried under } z \text{ blocks.”}
-\]
+$$
 
 For clarity, the *canonical Bitcoin chain* is defined as the valid header chain with **maximal cumulative proof-of-work**, as determined by standard Bitcoin consensus rules.
 
-Zenon does not execute Bitcoin logic. It verifies only the cryptographic evidence sufficient to establish \(S(tx, z)\).
+Zenon does not execute Bitcoin logic. It verifies only the cryptographic evidence sufficient to establish $S(tx, z)$.
 
 ---
 
@@ -57,49 +57,47 @@ Zenon does not execute Bitcoin logic. It verifies only the cryptographic evidenc
 
 The prover submits a minimal SPV proof package:
 
-\[
-\pi := (H_{0..n},\; tx,\; \text{merkle\_branch},\; b)
-\]
+$`\pi := (H_{0..n},\; tx,\; \text{merkle}\_\text{branch},\; b)`$
 
 Where:
-- \(H_{0..n}\): a sequence of Bitcoin block headers
-- \(tx\): the transaction data or hash
-- \(\text{merkle\_branch}\): sibling hashes reconstructing the Merkle root
-- \(b\): index of the block containing \(tx\)
+- $H_{0..n}$: a sequence of Bitcoin block headers
+- $tx$: the transaction data or hash
+- $`\text{merkle}\_\text{branch}`$: sibling hashes reconstructing the Merkle root
+- $b$: index of the block containing $tx$
 
 ---
 
 ### 2.3 Verification Predicate
 
-The verification function \(V(\pi, z) \to \{0,1\}\) evaluates true iff all conditions hold:
+The verification function $V(\pi, z) \to \{0,1\}$ evaluates true iff all conditions hold:
 
 - **PoW Validity**
-  \[
+  $$
   \mathrm{SHA256}^2(H_i) \le T_i
-  \]
+  $$
 
 - **Maximal Chainwork**
-  \[
+  $$
   W_i = \left\lfloor \frac{2^{256}}{T_i + 1} \right\rfloor,\quad
   W_{\text{chain}} = \sum_i W_i
-  \]
+  $$
 
 - **Merkle Inclusion**
-  \[
+  $$
   \mathrm{MerkleRoot}(tx,\text{branch}) = R(H_b)
-  \]
+  $$
 
 - **Confirmation Depth**
-  \[
+  $$
   n - b \ge z
-  \]
+  $$
 
 **Security Note:**  
-For an attacker with hashpower fraction \(q < 0.5\), the probability of reversing a transaction decays exponentially:
+For an attacker with hashpower fraction $q < 0.5$, the probability of reversing a transaction decays exponentially:
 
-\[
+$$
 P_{\text{reorg}} \approx \left(\frac{q}{1-q}\right)^z
-\]
+$$
 
 This bound applies to the Bitcoin domain and is independent of Zenon.
 
@@ -124,7 +122,7 @@ Produce a platform-agnostic, deterministic Bitcoin SPV verifier.
 - Comprehensive test vectors
 
 **Acceptance Criterion:**  
-For any proof \(\pi\), all conforming implementations must return identical \(V(\pi, z)\).
+For any proof $\pi$, all conforming implementations must return identical $V(\pi, z)$.
 
 **Threat Modeling:**
 - Eclipse attacks (false header feeds)
@@ -148,10 +146,10 @@ Verification cost is paid by the invoking account using existing resource mechan
 
 **Resource Bounds:**  
 To prevent abuse:
-\[
+$$
 C(\pi) \approx 2h + k \le C_{\max}
-\]
-where \(h\) is header count and \(k\) is Merkle branch length.
+$$
+where $h$ is header count and $k$ is Merkle branch length.
 
 **Outcome:**  
 Only the local account state is updated. Momentum does not re-verify proofs.
@@ -164,10 +162,10 @@ Only the local account state is updated. Momentum does not re-verify proofs.
 Mitigate header availability and eclipse risks.
 
 **Option A — Threshold Relaying:**  
-Accept a header tip \(\hat{t}\) only if observed from at least \(k\) independent sources:
-\[
+Accept a header tip $\hat{t}$ only if observed from at least $k$ independent sources:
+$$
 \#\{s_j : \mathrm{tip}(s_j)=\hat{t}\} \ge k
-\]
+$$
 
 This threshold mechanism mitigates eclipse risk but does **not** constitute a separate consensus system or introduce new trust assumptions beyond standard SPV verification.
 
@@ -189,7 +187,7 @@ BTC_FACT(txid, depth, root)
 **Workflow:**
 1. Local verification (Phase 1)
 2. Fact submission to Momentum
-3. Challenge window \(T\)
+3. Challenge window $T$
 4. Fraud proof submission (higher-work fork or invalid proof)
 
 Invalid facts are reverted; submitters may be penalized.
@@ -202,7 +200,7 @@ Invalid facts are reverted; submitters may be penalized.
 Ensure liveness and data availability after correctness is established.
 
 **Models:**
-- **Bonded Relayers:** stake \(B\), slash \(\alpha B\) on invalid data
+- **Bonded Relayers:** stake $B$, slash $\alpha B$ on invalid data
 - **Service Credits:** reward accurate header provision with resource privileges
 
 ---


### PR DESCRIPTION
There's a conflict with the GitHub's md parser and its math engine. If the \text includes an `_`, we should use the [recommended syntax](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions#writing-inline-expressions) to escape the md parser.