### PR TITLE
Restore canonical Taproot artifact rendering and add machine verifier

### DIFF
--- a/puzzle/README.md
+++ b/puzzle/README.md
@@ -51,21 +51,13 @@ Each transaction embeds a fragment of the artifact via `OP_RETURN`.
 
 ### 🔗 Header Fields
 TXID: 31fd67de5583a60078e6b409560e9e2bc84e56c336178f3bedb627c0d2ae3b95
-OP_RETURN: ;BynQtpeUyWTXKGTrGhdV2Q==;
+OP_RETURN: `      ;BynQtpeUyWTXKGTrGhdV2Q==;      `
 
 TXID: 1dbe3537dc4a19e1abad6da64f2689227cb186da81268ab49f825d69eb881897
-OP_RETURN: ;tVMd3L1CKM4wFmyxEEEUV2bY;
+OP_RETURN: `      ;tVMd3L1CKM4wFmyxEEEUV2bY;      `
 
 TXID: 71d9187cbb7b00b4c516df218499bbc301996262cfafc4533fd7916af1fb6315
-OP_RETURN: ;4Fdzw1k=zzzzzzzzzzzzzzzz;
-
-
----
-
-### 🔗 Embedded Field
-
-TXID: 57b5f224beb471fa78caeca665229166ec96da7798e5d05b15e37c07276a2476
-OP_RETURN: ,vtv3f5aKY0jGQglP9a1AGw==.
+OP_RETURN: `      ;4Fdzw1k=zzzzzzzzzzzzzzzz;      `
 
 
 ---
@@ -73,48 +65,27 @@ OP_RETURN: ,vtv3f5aKY0jGQglP9a1AGw==.
 ### 🔗 Canopy / Upper Structure
 
 TXID: 19b3689ee5798131201f73a896967f7b854ed4fecd29b58f9ba27b9e7f7b609d
-OP_RETURN: .:1zzzzzzzzz.
+OP_RETURN: `                  .:1zzzzzzzzz.       `
 
 TXID: 1025eece7a17734f89235f549a5be711b80121c792a54a406f3ba8cb66a192a3
-OP_RETURN: .:qqzzzzqqq,
+OP_RETURN: `                .:qqzzzzqqq,          `
 
 TXID: 30912564f5713e1208469a639289e762f4409e799195a686660a378a6f902f5f
-OP_RETURN: ,;1zzzzzqqq,
+OP_RETURN: `             ,;1zzzzzqqq,             `
 
 TXID: 22a4216df563bca11f4ebb90b11b0b57c158a4358e6917ff733153f6180a59c5
-OP_RETURN: ,;1zzzzzqqq,
+OP_RETURN: `          ,;1zzzzzqqq,                `
 
 TXID: 488c0d5773d10b0d6268c6086d794071964def58aec05bb9dcf0769dfed9bb4a
-OP_RETURN: ,;qzzzzz1qq,
+OP_RETURN: `       ,;qzzzzz1qq,                   `
 
 
 ---
 
-### 🔗 Trunk / Lower Structure
+### 🔗 Embedded Field
 
-TXID: d4d7ec6fcef9e8a3ea9fc726e43b631d0a6a7c702bec157e2ed10c030fc2b329
-OP_RETURN: ,zzzzzq;. 1zzzz,
-
-TXID: b8aa79a2c142dea65cdd315055ddadaa7a54c00789347aaf87685d9939e57ba0
-OP_RETURN: ,zzzzzzzzq, 1zzzz,
-
-TXID: 3fb6ecc1998106e08c6c334c7a72c4ec917f3b1905eebc7edc09040bfbae97cb
-OP_RETURN: ,zzzzzzzzzz1: 1zzzz,
-
-TXID: 2830adbb9d5cc96557604723af852a8296733ee33eab4b91e9f5d6f6580ce061
-OP_RETURN: ,zzzzq:1zzzzzq;. 1zzzz,
-
-TXID: 100b3fb55f7a5f599eead052d372f0a8df0299190b061052fc859370a4223030
-OP_RETURN: ,zzzzq ,qzzzzzz1, 1zzzz,
-
-TXID: 34e16ce83555309c86529bd8bb409fc157088b5810e1dbdfb1f6edd8604f885f
-OP_RETURN: ,zzzzq .;qzzzzzq:1zzzz,
-
-TXID: 67ff285453eb346b685580d354a5341289d2f7b6eed2df9b009f9cd10ee4266e
-OP_RETURN: ,zzzzq .;qzzzzzzz,
-
-TXID: b63c7002d5bade2530e1603af839198d4124de5799c16b863757fe0f79f181a8
-OP_RETURN: ,zzzzq ,qzzzzzzzzzz,
+TXID: 57b5f224beb471fa78caeca665229166ec96da7798e5d05b15e37c07276a2476
+OP_RETURN: `      ,vtv3f5aKY0jGQglP9a1AGw==.      `
 
 
 ---
@@ -122,10 +93,39 @@ OP_RETURN: ,zzzzq ,qzzzzzzzzzz,
 ### 🔗 Structural Padding / Base Rows
 
 TXID: f985bca535579e9d63ada9bc7ee0bfc2365acf0116abc5bb19d24292b5cc7f97
-OP_RETURN: ,zzzzzzzzzzzzzzzzzzzzzzzz,
+OP_RETURN: `      ,zzzzzzzzzzzzzzzzzzzzzzzz,      `
 
 TXID: 86a2ce16fab79157cc8b38a4c5bb6c0ef1ddc284b0fd9e0f47d99d3fa154b7dd
-OP_RETURN: ,zzzzzzzzzzzzzzzzzzzzzzzz,
+OP_RETURN: `      ,zzzzzzzzzzzzzzzzzzzzzzzz,      `
+
+
+---
+
+### 🔗 Trunk / Lower Structure
+
+TXID: d4d7ec6fcef9e8a3ea9fc726e43b631d0a6a7c702bec157e2ed10c030fc2b329
+OP_RETURN: `      ,zzzzzq;.           1zzzz,      `
+
+TXID: b8aa79a2c142dea65cdd315055ddadaa7a54c00789347aaf87685d9939e57ba0
+OP_RETURN: `      ,zzzzzzzzq,         1zzzz,      `
+
+TXID: 3fb6ecc1998106e08c6c334c7a72c4ec917f3b1905eebc7edc09040bfbae97cb
+OP_RETURN: `      ,zzzzzzzzzz1:       1zzzz,      `
+
+TXID: 2830adbb9d5cc96557604723af852a8296733ee33eab4b91e9f5d6f6580ce061
+OP_RETURN: `      ,zzzzq:1zzzzzq;.    1zzzz,      `
+
+TXID: 100b3fb55f7a5f599eead052d372f0a8df0299190b061052fc859370a4223030
+OP_RETURN: `      ,zzzzq  ,qzzzzzz1,  1zzzz,      `
+
+TXID: 34e16ce83555309c86529bd8bb409fc157088b5810e1dbdfb1f6edd8604f885f
+OP_RETURN: `      ,zzzzq    .;qzzzzzq:1zzzz,      `
+
+TXID: b63c7002d5bade2530e1603af839198d4124de5799c16b863757fe0f79f181a8
+OP_RETURN: `      ,zzzzq       ,qzzzzzzzzzz,      `
+
+TXID: 67ff285453eb346b685580d354a5341289d2f7b6eed2df9b009f9cd10ee4266e
+OP_RETURN: `      ,zzzzq         .;qzzzzzzz,      `
 
 
 ---
@@ -140,13 +140,40 @@ OP_RETURN: ZENON NETWORK
 
 ## 5. Full Artifact Reconstruction
 
-When concatenated in structural order, the transactions reconstruct a **multi-layer ASCII artifact** containing:
+When assembled in structural order, the transactions reconstruct a **multi-layer ASCII artifact** containing:
 
 - 3 header Base64 fields  
-- 1 embedded Base64 field  
 - 5-row canopy structure  
+- 1 embedded Base64 field  
+- 2 structural padding/base rows  
 - 8-row trunk structure  
 - terminal marker  
+
+```text
+      ;BynQtpeUyWTXKGTrGhdV2Q==;
+      ;tVMd3L1CKM4wFmyxEEEUV2bY;
+      ;4Fdzw1k=zzzzzzzzzzzzzzzz;
+
+                  .:1zzzzzzzzz.
+                .:qqzzzzqqq,
+             ,;1zzzzzqqq,
+          ,;1zzzzzqqq,
+       ,;qzzzzz1qq,
+
+      ,vtv3f5aKY0jGQglP9a1AGw==.
+
+      ,zzzzzzzzzzzzzzzzzzzzzzzz,
+      ,zzzzzzzzzzzzzzzzzzzzzzzz,
+      ,zzzzzq;.           1zzzz,
+      ,zzzzzzzzq,         1zzzz,
+      ,zzzzzzzzzz1:       1zzzz,
+      ,zzzzq:1zzzzzq;.    1zzzz,
+      ,zzzzq  ,qzzzzzz1,  1zzzz,
+      ,zzzzq    .;qzzzzzq:1zzzz,
+      ,zzzzq       ,qzzzzzzzzzz,
+      ,zzzzq         .;qzzzzzzz,
+ZENON NETWORK
+```
 
 ---
 

--- a/puzzle/scripts/verify_machine_spec.go
+++ b/puzzle/scripts/verify_machine_spec.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"sort"
+)
+
+var (
+	b64A = "BynQtpeUyWTXKGTrGhdV2Q=="
+	b64B = "tVMd3L1CKM4wFmyxEEEUV2bY"
+	b64C = "4Fdzw1k="
+	b64E = "vtv3f5aKY0jGQglP9a1AGw=="
+
+	expA = []byte{0x07, 0x29, 0xd0, 0xb6, 0x97, 0x94, 0xc9, 0x64, 0xd7, 0x28, 0x64, 0xeb, 0x1a, 0x17, 0x55, 0xd9}
+	expB = []byte{0xb5, 0x53, 0x1d, 0xdc, 0xbd, 0x42, 0x28, 0xce, 0x30, 0x16, 0x6c, 0xb1, 0x10, 0x41, 0x14, 0x57, 0x66, 0xd8}
+	expC = []byte{0xe0, 0x57, 0x73, 0xc3, 0x59}
+	expE = []byte{0xbe, 0xdb, 0xf7, 0x7f, 0x96, 0x8a, 0x63, 0x48, 0xc6, 0x42, 0x09, 0x4f, 0xf5, 0xad, 0x40, 0x1b}
+)
+
+type verifier struct {
+	passed int
+	failed int
+}
+
+func (v *verifier) check(name string, ok bool, details string) {
+	if ok {
+		v.passed++
+		fmt.Printf("PASS %-32s %s\n", name, details)
+		return
+	}
+	v.failed++
+	fmt.Printf("FAIL %-32s %s\n", name, details)
+}
+
+func mustDecode(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func eq(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func hexBytes(b []byte) string {
+	out := ""
+	for i, x := range b {
+		if i > 0 {
+			out += " "
+		}
+		out += fmt.Sprintf("%02x", x)
+	}
+	return out
+}
+
+func main() {
+	v := &verifier{}
+
+	A := mustDecode(b64A)
+	B := mustDecode(b64B)
+	C := mustDecode(b64C)
+	E := mustDecode(b64E)
+
+	v.check("base64 A", eq(A, expA), hexBytes(A))
+	v.check("base64 B", eq(B, expB), hexBytes(B))
+	v.check("base64 C", eq(C, expC), hexBytes(C))
+	v.check("base64 E", eq(E, expE), hexBytes(E))
+
+	Hdr := B[0:3]
+	G1 := B[3:6]
+	G2 := B[6:9]
+	G3 := B[9:12]
+	G4 := B[12:15]
+	G5 := B[15:18]
+	groups := [][]byte{G1, G2, G3, G4, G5}
+
+	v.check("B partition Hdr", eq(Hdr, []byte{0xb5, 0x53, 0x1d}), hexBytes(Hdr))
+	v.check("B partition G1", eq(G1, []byte{0xdc, 0xbd, 0x42}), hexBytes(G1))
+	v.check("B partition G2", eq(G2, []byte{0x28, 0xce, 0x30}), hexBytes(G2))
+	v.check("B partition G3", eq(G3, []byte{0x16, 0x6c, 0xb1}), hexBytes(G3))
+	v.check("B partition G4", eq(G4, []byte{0x10, 0x41, 0x14}), hexBytes(G4))
+	v.check("B partition G5", eq(G5, []byte{0x57, 0x66, 0xd8}), hexBytes(G5))
+
+	selectors := []int{}
+	for i, x := range E {
+		if int(x) < len(B) {
+			selectors = append(selectors, i)
+		}
+	}
+	v.check("E unique direct selector", len(selectors) == 1 && selectors[0] == 10 && E[10] == 0x09, fmt.Sprintf("indices=%v value=%02x", selectors, E[10]))
+	v.check("selector extracts G3", eq(B[E[10]:E[10]+3], G3), hexBytes(B[E[10]:E[10]+3]))
+
+	mask := (G3[0] ^ G3[2]) & 0x07
+	out := G3[1] ^ mask
+	v.check("kernel mask", mask == 0x07, fmt.Sprintf("mask=%02x", mask))
+	v.check("kernel output", out == 0x6b, fmt.Sprintf("out=%02x", out))
+	v.check("bridge kernel->E[3]", out^G4[2] == E[3], fmt.Sprintf("%02x ^ %02x = %02x", out, G4[2], out^G4[2]))
+	v.check("selector bridge", E[10]^G4[2] == Hdr[2], fmt.Sprintf("%02x ^ %02x = %02x", E[10], G4[2], E[10]^G4[2]))
+	v.check("header OR relation", G3[2]|G4[2] == Hdr[0], fmt.Sprintf("%02x | %02x = %02x", G3[2], G4[2], G3[2]|G4[2]))
+	v.check("G4 contained in Hdr", (Hdr[0]&G4[0] == G4[0]) && (Hdr[1]&G4[1] == G4[1]) && (Hdr[2]&G4[2] == G4[2]), fmt.Sprintf("Hdr&G4=%02x %02x %02x", Hdr[0]&G4[0], Hdr[1]&G4[1], Hdr[2]&G4[2]))
+
+	seq := make([]byte, len(E))
+	for i, x := range E {
+		seq[i] = groups[int(x)%5][int(x)%3]
+	}
+	expSeq := []byte{0xbd, 0x57, 0x6c, 0x6c, 0xdc, 0x10, 0x57, 0x16, 0x10, 0x28, 0x57, 0x66, 0x42, 0x14, 0x66, 0x16}
+	v.check("selector sequence", eq(seq, expSeq), hexBytes(seq))
+
+	printable := map[byte]bool{}
+	for _, x := range B {
+		if x >= 0x20 && x <= 0x7e {
+			printable[x] = true
+		}
+	}
+	keys := make([]int, 0, len(printable))
+	for x := range printable {
+		keys = append(keys, int(x))
+	}
+	sort.Ints(keys)
+	printableHex := ""
+	for i, x := range keys {
+		if i > 0 {
+			printableHex += " "
+		}
+		printableHex += fmt.Sprintf("%02x", x)
+	}
+	v.check("printable subset B", printableHex == "28 30 41 42 53 57 66 6c", printableHex)
+
+	type pair struct{ i, j int }
+	pairs := []pair{}
+	for i := 0; i < len(A); i++ {
+		for j := i + 1; j < len(A); j++ {
+			d := int(A[i]) - int(A[j])
+			if d < 0 {
+				d = -d
+			}
+			if d <= 1 && printable[seq[i]] && printable[seq[j]] {
+				pairs = append(pairs, pair{i, j})
+			}
+		}
+	}
+	v.check("unique adjacency pair", len(pairs) == 1 && pairs[0] == (pair{1, 9}), fmt.Sprintf("pairs=%v A=(%02x,%02x)", pairs, A[9], A[1]))
+
+	concat := b64A + b64B + b64C + b64E
+	projection := concat[40:44]
+	decodedProjection := mustDecode(projection)
+	v.check("base64 projection to G4", projection == "EEEU" && eq(decodedProjection, G4), fmt.Sprintf("%s -> %s", projection, hexBytes(decodedProjection)))
+
+	derivedA := map[int]byte{
+		0:  mask,
+		1:  Hdr[1] >> 1,
+		2:  G3[2] ^ mask ^ G5[1],
+		3:  G3[2] ^ mask,
+		4:  E[4] | mask,
+		5:  Hdr[0] & G1[0],
+		6:  G5[2] ^ G3[0] ^ mask,
+		7:  E[6] ^ mask,
+		8:  ^G2[0],
+		9:  G2[0],
+		11: G2[2] ^ E[1],
+		12: Hdr[2] ^ mask,
+		13: G4[0] ^ mask,
+		14: G4[0] | G4[1] | G4[2],
+		15: Hdr[0] ^ G3[1],
+	}
+	okA := true
+	for i, x := range derivedA {
+		if A[i] != x {
+			okA = false
+		}
+	}
+	v.check("A-field derivations", okA, "A[10] intentionally not derived")
+	v.check("A[10] duplicates A[7]", A[10] == A[7], fmt.Sprintf("A[10]=%02x A[7]=%02x", A[10], A[7]))
+
+	v.check("secondary G2[1]^G3[2]", G2[1]^G3[2] == E[3], fmt.Sprintf("%02x", G2[1]^G3[2]))
+	v.check("secondary G5[1]^G5[2]", G5[1]^G5[2] == E[0], fmt.Sprintf("%02x", G5[1]^G5[2]))
+	v.check("secondary G3[0]+G4[1]", byte(uint16(G3[0])+uint16(G4[1])) == G5[0], fmt.Sprintf("%02x", byte(uint16(G3[0])+uint16(G4[1]))))
+	v.check("secondary G3[1]+G3[2]", byte(uint16(G3[1])+uint16(G3[2])) == Hdr[2], fmt.Sprintf("%02x", byte(uint16(G3[1])+uint16(G3[2]))))
+
+	fmt.Printf("\n%d passed, %d failed\n", v.passed, v.failed)
+	if v.failed > 0 {
+		os.Exit(1)
+	}
+}

--- a/puzzle/zenon_taproot_partial_solve.md
+++ b/puzzle/zenon_taproot_partial_solve.md
@@ -47,7 +47,7 @@ This document addresses:
 
 - Mechanical extraction of all Base64 fields
 - Structural row alignment across fields
-- Canopy generation layer (structural quantities locked; full character-sequence renderer open)
+- Canopy generation layer (row alignment and render channels identified; exact renderer open)
 - Trunk rewrite system (7/7 forward predictions confirmed)
 - E-layer selector anomaly (exhaustively enumerated; uniqueness confirmed)
 - Row 6 as the proof locus (five independent convergence signals)
@@ -73,31 +73,32 @@ All claims are accompanied by their falsification conditions.
 
 ### 2.1 Canonical Artifact
 
-The artifact as embedded in Bitcoin block 709,632:
+The artifact from Bitcoin block 709,632, rendered by structural region:
 
-```
-;BynQtpeUyWTXKGTrGhdV2Q==;
-;tVMd3L1CKM4wFmyxEEEUV2bY;
-;4Fdzw1k=zzzzzzzzzzzzzzzz;
+```text
+      ;BynQtpeUyWTXKGTrGhdV2Q==;
+      ;tVMd3L1CKM4wFmyxEEEUV2bY;
+      ;4Fdzw1k=zzzzzzzzzzzzzzzz;
 
-               .:1zzzzzzzzz.
-             .:qqzzzzqqqq,
-           ,;1zzzzzzqqqq,
-         ,;1zzzzzqqqq,
+                  .:1zzzzzzzzz.
+                .:qqzzzzqqq,
+             ,;1zzzzzqqq,
+          ,;1zzzzzqqq,
        ,;qzzzzz1qq,
 
-,vtv3f5aKY0jGQglP9a1AGw==.
+      ,vtv3f5aKY0jGQglP9a1AGw==.
 
-,zzzzzzzzzzzzzzzzzzzzzzzz,
-,zzzzzzzzzzzzzzzzzzzzzzzz,
-,zzzzzq;.          1zzzz,
-,zzzzzzzzq,        1zzzz,
-,zzzzzzzzzz1:      1zzzz,
-,zzzzq:1zzzzzq;.   1zzzz,
-,zzzzq  ,qzzzzzzz1, 1zzzz,
-,zzzzq    .;qzzzzzq:1zzzz,
-,zzzzq        ,qzzzzzzzzzzz,
-,zzzzq            .;qzzzzzzzzz,
+      ,zzzzzzzzzzzzzzzzzzzzzzzz,
+      ,zzzzzzzzzzzzzzzzzzzzzzzz,
+      ,zzzzzq;.           1zzzz,
+      ,zzzzzzzzq,         1zzzz,
+      ,zzzzzzzzzz1:       1zzzz,
+      ,zzzzq:1zzzzzq;.    1zzzz,
+      ,zzzzq  ,qzzzzzz1,  1zzzz,
+      ,zzzzq    .;qzzzzzq:1zzzz,
+      ,zzzzq       ,qzzzzzzzzzz,
+      ,zzzzq         .;qzzzzzzz,
+ZENON NETWORK
 ```
 
 ### 2.2 Field Identification
@@ -212,17 +213,17 @@ requires that all three counts match without intent only by extreme coincidence.
 
 ### 4.1 Canonical Canopy Rows
 
-```
-R1:  .:1zzzzzzzzz.
-R2:    .:qqzzzzqqqq,
-R3:  ,;1zzzzzzqqqq,
-R4:  ,;1zzzzzqqqq,
-R5:  ,;qzzzzz1qq,
+```text
+R1:                  .:1zzzzzzzzz.
+R2:                .:qqzzzzqqq,
+R3:             ,;1zzzzzqqq,
+R4:          ,;1zzzzzqqq,
+R5:       ,;qzzzzz1qq,
 ```
 
 ### 4.2 Observed Per-Row Structural Quantities
 
-For each row, three quantities are directly measurable:
+For each row, three quantities are directly measurable on the trimmed row body:
 
 - **L** = total character count
 - **Nz** = count of `z` characters
@@ -230,55 +231,49 @@ For each row, three quantities are directly measurable:
 
 | Row | L | Nz | Nq | B_mid byte | C byte |
 |---|---|---|---|---|---|
-| 1 | 14 | 9 | 0 | `bd` | `e0` |
-| 2 | 14 | 4 | 4 | `ce` | `57` |
-| 3 | 14 | 6 | 4 | `6c` | `73` |
-| 4 | 13 | 5 | 3 | `41` | `c3` |
-| 5 | 12 | 5 | 2 | `66` | `59` |
+| 1 | 13 | 9 | 0 | `bd` | `e0` |
+| 2 | 12 | 4 | 5 | `ce` | `57` |
+| 3 | 12 | 5 | 3 | `6c` | `73` |
+| 4 | 12 | 5 | 3 | `41` | `c3` |
+| 5 | 12 | 5 | 3 | `66` | `59` |
 
 ### 4.3 Derivable Structural Correspondences ⚠️
 
-The following correspondences survive direct computation and hostile review:
+The following correspondences survive direct computation on the canonical canopy rows:
 
-**Row length modular structure** (L_i mod (C_i & 0x0F)):
+**Row length structure**:
 
-| Row | Computation | Result |
+| Row | L | C low nibble |
 |---|---|---|
-| 1 | 14 mod 0 | degenerate (skip) |
-| 2 | 14 mod 7 | 0 |
-| 3 | 14 mod 3 | 2 |
-| 4 | 13 mod 3 | 1 |
-| 5 | 12 mod 9 | 3 |
+| 1 | 13 | 0 |
+| 2 | 12 | 7 |
+| 3 | 12 | 3 |
+| 4 | 12 | 3 |
+| 5 | 12 | 9 |
 
-Residue sequence 0, 2, 1, 3 is consistent with a monotone traversal governed by C's low nibble.
+**q-count vs B high nibble**:
 
-**q-count vs B high nibble** (rows 3–5 satisfy Nq = B_hi − δ for stable δ):
-
-| Row | Nq | B_hi | Formula |
-|---|---|---|---|
-| 3 | 4 | 6 | 6 − 2 = 4 ✓ |
-| 4 | 3 | 4 | 4 − 1 = 3 ✓ |
-| 5 | 2 | 6 | 6 − 4 = 2 ✓ |
+| Row | Nq | B_hi |
+|---|---|---|
+| 1 | 0 | `b`=11 |
+| 2 | 5 | `c`=12 |
+| 3 | 3 | `6`=6 |
+| 4 | 3 | `4`=4 |
+| 5 | 3 | `6`=6 |
 
 **z-count vs B low nibble and C low nibble**:
 
-| Row | Nz | B_lo | C_lo | Formula |
-|---|---|---|---|---|
-| 1 | 9 | `d`=13 | 0 | 13 − 4 = 9 ✓ |
-| 2 | 4 | `e`=14 | 7 | 14 − 7 − 3 = 4 ✓ |
-| 3 | 6 | `c`=12 | 3 | 12 − 3 − 3 = 6 ✓ |
-| 4 | 5 | `1`=1 | 3 | (1 + 3) + 1 = 5 ✓ |
-| 5 | 5 | `8`=8 | 9 | (8 + 9) mod 12 = 5 ✓ |
+| Row | Nz | B_lo | C_lo |
+|---|---|---|---|
+| 1 | 9 | `d`=13 | 0 |
+| 2 | 4 | `e`=14 | 7 |
+| 3 | 5 | `c`=12 | 3 |
+| 4 | 5 | `1`=1 | 3 |
+| 5 | 5 | `8`=8 | 9 |
 
 ### 4.4 Canopy Generator Model ⚠️
 
-Each canopy row's structural quantities are functions of its aligned (G_i, C_i) pair:
-
-```
-Row_i.Nz = f_z(B_i[lo], C_i[lo])
-Row_i.Nq = f_q(B_i[hi])
-Row_i.L  = f_L(C_i[lo])
-```
+The five canopy rows align 1:1 with `G1..G5` and the five C bytes.
 
 The four render channels are:
 
@@ -286,19 +281,19 @@ The four render channels are:
 |---|---|---|
 | PrefixFamily | G_i, C_i | Binary `:. ` vs `,;` — selector unresolved |
 | PivotClass | C_i low nibble | ONE / QQ / Q — partial |
-| TailClass | C_i | NULL / Q4 / MIXED — partial |
-| BodyAlloc | Residual after Pivot and Tail | Derivable |
+| TailClass | C_i | NULL / Q3 / MIXED — partial |
+| BodyAlloc | Residual after Pivot and Tail | Derivable from row body |
 
-🔒 **Partial lock:** Row structural quantities (L, Nz, Nq) are deterministically governed by B and C. Full character-sequence reproducibility is the primary open problem.
+⚠️ **Partial lock:** Row alignment and render channels are preserved. Full character-sequence reproducibility from byte-level inputs remains the primary open problem.
 
 ### 4.5 Symbolic Decomposition
 
 | Row | Prefix | Pivot | ZSpan | Tail | End |
 |---|---|---|---|---|---|
 | R1 | `.:` | `1` | 9 | ∅ | `.` |
-| R2 | `.:` | `qq` | 4 | `qqqq` | `,` |
-| R3 | `,;` | `1` | 6 | `qqqq` | `,` |
-| R4 | `,;` | `1` | 5 | `qqqq` | `,` |
+| R2 | `.:` | `qq` | 4 | `qqq` | `,` |
+| R3 | `,;` | `1` | 5 | `qqq` | `,` |
+| R4 | `,;` | `1` | 5 | `qqq` | `,` |
 | R5 | `,;` | `q` | 5 | `1qq` | `,` |
 
 ---
@@ -307,15 +302,15 @@ The four render channels are:
 
 ### 5.1 Canonical Trunk Rows
 
-```
-R1:  ,zzzzzq;.          1zzzz,
-R2:  ,zzzzzzzzq,        1zzzz,
-R3:  ,zzzzzzzzzz1:      1zzzz,
-R4:  ,zzzzq:1zzzzzq;.   1zzzz,
-R5:  ,zzzzq  ,qzzzzzzz1, 1zzzz,
-R6:  ,zzzzq    .;qzzzzzq:1zzzz,
-R7:  ,zzzzq        ,qzzzzzzzzzzz,
-R8:  ,zzzzq            .;qzzzzzzzzz,
+```text
+R1:      ,zzzzzq;.           1zzzz,
+R2:      ,zzzzzzzzq,         1zzzz,
+R3:      ,zzzzzzzzzz1:       1zzzz,
+R4:      ,zzzzq:1zzzzzq;.    1zzzz,
+R5:      ,zzzzq  ,qzzzzzz1,  1zzzz,
+R6:      ,zzzzq    .;qzzzzzq:1zzzz,
+R7:      ,zzzzq       ,qzzzzzzzzzz,
+R8:      ,zzzzq         .;qzzzzzzz,
 ```
 
 ### 5.2 Core Notation
@@ -851,7 +846,7 @@ The Zenon Taproot artifact contains a uniquely privileged local core fragment, G
 ### 15.4 Current Machine Summary
 
 ```
-B + C  →  canopy generator (structural quantities locked; full sequence open)
+B + C  →  canopy alignment and render-channel candidates (exact renderer open)
 A      →  trunk control layer (phase schedule 00,11,11,10,10,01,00,01)
 Trunk  →  visible execution path / rewrite machine (7/7 forward predictions)
 E      →  marker overlay (sole legal selector at row 6-left)
@@ -867,7 +862,7 @@ G3     →  compressed core artifact (score 22, uniquely highest)
 
 **Status:** Primary open problem.
 
-Structural quantities (L, Nz, Nq) are derivable from B and C. The remaining gap is the exact row-rendering law that reproduces every character position, punctuation placement, and symbol ordering within each canopy row. The four render channels (PrefixFamily, PivotClass, TailClass, BodyAlloc) have been identified, but the precise byte-level selectors within each channel remain unresolved.
+The canopy rows align with `G1..G5` and the five C bytes, and their render channels (PrefixFamily, PivotClass, TailClass, BodyAlloc) are directly identifiable from the artifact. The remaining gap is the exact row-rendering law that reproduces every character position, punctuation placement, and symbol ordering within each canopy row from byte-level inputs.
 
 **Next step:** Identify the second canopy channel — likely pivot position within each row or the z/q boundary location — which, combined with pivot identity, would provide two-dimensional canopy encoding sufficient to move from partial lock to full lock.
 
@@ -939,7 +934,7 @@ STATUS: LOCAL STATE MACHINE IDENTIFIED — S1 through S7
 STATUS: CONSERVED CORRIDOR CORE IDENTIFIED — 00 40 10
 STATUS: WHOLE-ARTIFACT ASYMMETRY ESTABLISHED
 STATUS: B ARCHITECTURE RESOLVED — Canopy / Proof Corridor / Canopy
-STATUS: CANOPY STRUCTURAL QUANTITIES DERIVABLE — full sequence open
+STATUS: CANOPY RENDER CHANNELS IDENTIFIED — exact renderer open
 STATUS: TRUNK REWRITE SYSTEM FORWARD-PREDICTIVE — 7/7 (overfitting addressed)
 STATUS: CANOPY PIVOT CHANNEL LOCKED — yields 0x09 or 0x16 by polarity
 STATUS: ZENON PROTOCOL CORRESPONDENCE MAPPED — 12-layer equivalence table
@@ -948,4 +943,4 @@ STATUS: NO FORCED EXTERNAL DECODE — internal closure is current strongest endp
 
 ---
 
-*Document compiled from iterative hostile-review cycles. All errors corrected under review have been incorporated, including: OP_PUSH22 label correction (0x16), canopy arithmetic consistency verification, and epistemic scope restrictions on all unproven claims.*
+*Document compiled from iterative hostile-review cycles. All errors corrected under review have been incorporated, including: OP_PUSH22 label correction (0x16), and epistemic scope restrictions on all unproven claims.*


### PR DESCRIPTION
This PR restores the Taproot puzzle artifact to a canonical 1:1 rendering of the on-chain OP_RETURN payloads. It also updates canopy measurements that depended on the previous non-canonical rendering, and adds a Go verifier for the byte-level machine spec claims. 

The byte-level machine spec survives the incorrect artifact.                                        

   ## Changes

   - Preserve exact OP_RETURN spacing and row contents in `puzzle/README.md` 
   - Correct canopy and trunk ASCII rows from on-chain data                                                                               
   - Keep artifact regions visually separated:                                                                                            
     - 3 header rows                                                                                                                      
     - 5 canopy rows                                                                                                                      
     - embedded E row
     - 2 base/padding rows
     - 8 trunk rows                                                                                                                       
     - terminal marker                                                                                                                    
   - Update canopy `L / Nz / Nq` measurements                                                                                             
   - Downgrade canopy generator language where prior arithmetic no longer holds                                                           
   - Preserve still-valid OP_PUSH22 / G3 machine interpretation                                                                           
   - Add `puzzle/scripts/verify_machine_spec.go`

   ## Verification                                                                                                                        

   Ran:

   ```sh
   go run puzzle/scripts/verify_machine_spec.go                                                                                           
 ```

 Result:

 ```text
   28 passed, 0 failed                                                                                                                    
 ```

 The verifier covers the byte-level machine spec claims, including Base64 decoding, B partitioning, E selector uniqueness, G3 extraction, kernel relations, selector sequence, adjacency pair, A-field derivations, and secondary relations.
